### PR TITLE
Fix installer for RHEL7, broken on Docker verification with "No package docker-io available."

### DIFF
--- a/bin/npmo.js
+++ b/bin/npmo.js
@@ -57,11 +57,11 @@ function install (yargs) {
         console.log(chalk.red(err.message))
         return
       }
-      
-      //[npme@pppdc9prda2x npmo]$ cat /etc/redhat-release
+
+      // [npme@pppdc9prda2x npmo]$ cat /etc/redhat-release
       // RHEL7: Red Hat Enterprise Linux Server release 7.1 (Maipo)
-      // CENTOS7: CentOS Linux release 7.0.1406 (Core) 
-      var redHatOS = fs.readFileSync('/etc/redhat-release').toString();
+      // CENTOS7: CentOS Linux release 7.0.1406 (Core)
+      var redHatOS = fs.readFileSync('/etc/redhat-release').toString()
       if (redHatOS.indexOf('Enterprise') > 0) {
         content = content.replace('docker-io', 'docker-engine')
       }

--- a/bin/npmo.js
+++ b/bin/npmo.js
@@ -57,7 +57,14 @@ function install (yargs) {
         console.log(chalk.red(err.message))
         return
       }
-
+      
+      //[npme@pppdc9prda2x npmo]$ cat /etc/redhat-release
+      // RHEL7: Red Hat Enterprise Linux Server release 7.1 (Maipo)
+      // CENTOS7: CentOS Linux release 7.0.1406 (Core) 
+      var redHatOS = fs.readFileSync('/etc/redhat-release').toString();
+      if (redHatOS.indexOf("Enterprise") > 0) {
+        content = content.replace("docker-io", "docker-engine")
+      }
       fs.writeFileSync(path.resolve(cwd, './install.sh'), content, 'utf-8')
 
       exec('sh install.sh', argv.sudo, function (code) {

--- a/bin/npmo.js
+++ b/bin/npmo.js
@@ -62,8 +62,8 @@ function install (yargs) {
       // RHEL7: Red Hat Enterprise Linux Server release 7.1 (Maipo)
       // CENTOS7: CentOS Linux release 7.0.1406 (Core) 
       var redHatOS = fs.readFileSync('/etc/redhat-release').toString();
-      if (redHatOS.indexOf("Enterprise") > 0) {
-        content = content.replace("docker-io", "docker-engine")
+      if (redHatOS.indexOf('Enterprise') > 0) {
+        content = content.replace('docker-io', 'docker-engine')
       }
       fs.writeFileSync(path.resolve(cwd, './install.sh'), content, 'utf-8')
 


### PR DESCRIPTION
Problem
----

The current installer assumes the Docker RPM module is named `docker-io`. However, the name has been renamed to `docker-engine`. The installation halts with the following error message:

```sh
Nothing to do
No package docker-io available.
Error: Nothing to do
oh no! something went wrong during the install...
contact support@npmjs.com and we can help get you up and running
```

Solution
---- 

Update the script to properly rename the package during the installation. I could only properly install and setup the registry on RHEL 7 with this patch. Finally I have it on RHEL 7.

```sh
Complete!
Congrats! Your npm On-Site server is now up and running \o/

There are just a few final steps:

Step 1. Access this server in a web-browser via port 8800 (this will bring you to an admin console)
Step 2. Proceed passed the HTTPS connection security warning (a selfsigned cert is being used initially)
Step 3. Upload a custom TLS/SSL cert/key or proceed with the provided self-signed pair.
Step 4. Configure your npm instance & click "Save".
Step 5. Visit https://docs.npmjs.com/, for information about using npm On-Site or contact support@npmjs.com
```