### PR TITLE
you should be able to pin at specific package versions

### DIFF
--- a/bin/npmo.js
+++ b/bin/npmo.js
@@ -114,7 +114,9 @@ function addPackage (yargs) {
     .epilog("add a new package to your appliance's whitelist")
     .argv
 
-  exec(adminCommand + argv._.join(' '), argv.sudo, function () {})
+  var cmd = adminCommand + argv._.join(' ')
+  if (~cmd.indexOf('@')) cmd += ' --all-versions=false'
+  exec(cmd, argv.sudo, function () {})
 }
 
 function removePackage (yargs) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npmo",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "One-step-installer for npm On-Site servers",
   "bin": "bin/npmo.js",
   "scripts": {


### PR DESCRIPTION
The admin tool in its current state did not allow you to pin the whitelist to specific versions of modules.