### PR TITLE
Use -E with sudo to preserve environment

### DIFF
--- a/bin/npmo.js
+++ b/bin/npmo.js
@@ -189,7 +189,7 @@ function ssh (yargs) {
 
 function exec (command, sudo, cb) {
   var commands = ['-c']
-  if (sudo) command = 'sudo ' + command
+  if (sudo) command = 'sudo -E ' + command
   commands.push(command)
 
   var proc = spawn('sh', commands, {


### PR DESCRIPTION
If we use `sudo` without the `-E` flag, then environment variables from the interactive shell will not be preserved for the non-interactive shell command, which can subvert things like `HTTP_PROXY`, inadvertently precluding proxy detection logic in Replicated's `install.sh` script.

Here's a simple test script, executed in the manner of `bin/npmo.js`:

```sh
# file name: test.sh
echo $MERRY
```

```
$ MERRY=christmas sh -c "sudo sh test.sh"

$ MERRY=christmas sh -c "sudo -E sh test.sh"
christmas
```